### PR TITLE
Update examples and README.

### DIFF
--- a/Examples/Graph/Graph.fs
+++ b/Examples/Graph/Graph.fs
@@ -7,7 +7,7 @@ open System
 [<EntryPoint>]
 let main argv =
 
-    let fileName = getTemporaryFileNameWithExt "html"
+    let fileName = "Graph.html"
     let plot2 = Plot.plot[ for i in 0.0 .. 0.02 .. 2.0 * Math.PI -> (500.0 * cos i * sin i, 500.0 * sin i) ]
 
     Plot.plot [ for i in 0.0 .. 0.02 .. 2.0 * Math.PI -> (1000.0 * sin i, 1000.0 * cos i * sin i) ]

--- a/Examples/Life/Life.fsproj
+++ b/Examples/Life/Life.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/Triangle/Triangle.fsproj
+++ b/Examples/Triangle/Triangle.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Circle.create center radius
 Clone the repository:
 ```bash
 git clone https://github.com/ChrisNikkel/SharpVG.git
-cd SharpVG
+cd SharpVG/SharpVG
 ```
 
 Start the build:
@@ -85,7 +85,6 @@ Run the examples:
 dotnet run -p Examples\Triangle\Triangle.fsproj
 dotnet run -p Examples\Life\Life.fsproj
 dotnet run -p Examples\Graph\Graph.fsproj
-dotnet run -p Examples\Animate\Animate.fsproj
 ```
 
 Run the [Fable](http://fable.io) example ([prerequisites](http://fable.io/pages/prerequisites.html)):


### PR DESCRIPTION
Thank you for writing this, seems to be exactly what I was looking for. I encountered two problems on setup that I try to fix here:

1. Running dotnet build fails because of the fable dependency in the Bounce example.
2. The examples cannot be run with "dotnet run".

The Animation example seems to be commented out so I deleted it from the README.